### PR TITLE
Add some helpers in CountryProvider

### DIFF
--- a/src/Nager.Country.UnitTest/ValidationTest.cs
+++ b/src/Nager.Country.UnitTest/ValidationTest.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nager.Country;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Nager.Date.UnitTest
@@ -66,6 +67,92 @@ namespace Nager.Date.UnitTest
             if (countryInfo == null)
             {
                 Assert.Fail($"Found country not {countryCode}");
+            }
+        }
+
+        public void GetCountries()
+        {
+            ICountryProvider countryProvider = new CountryProvider();
+            var countries = countryProvider.GetCountries();
+
+            foreach (var countryCode in (Alpha2Code[])Enum.GetValues(typeof(Alpha2Code)))
+            {
+                if(countries.Any(x => x.Alpha2Code == countryCode) == false)
+                {
+                    Assert.Fail($"No country in all countries list for country code {countryCode}");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CheckAllCulture()
+        {
+            ICountryProvider countryProvider = new CountryProvider();
+            CultureInfo[] cultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+
+            foreach (var countryCode in (Alpha2Code[])Enum.GetValues(typeof(Alpha2Code)))
+            {
+                var countryInfo = countryProvider.GetCountry(countryCode);
+                if (countryInfo == null)
+                    continue;
+
+                var expectedLanguages = countryInfo.Translations.Select(x => x.LanguageCode).ToList();
+                foreach (var culture in cultures)
+                {
+                    bool expectResult = false;
+                    if (Enum.TryParse(culture.TwoLetterISOLanguageName, true, out LanguageCode code) == true)
+                    {
+                        expectResult = expectedLanguages.Any(x => x == code);
+                    }
+
+                    var translatedCountryName = countryProvider.GetCountryTranslatedName(countryCode, culture);
+                    if(expectResult == true && String.IsNullOrWhiteSpace(translatedCountryName) == true)
+                    {
+                        Assert.Fail($"A result was expected but there was no translated country name found for {countryCode} and culture {culture.Name} (language {culture.TwoLetterISOLanguageName})");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        [DataRow(LanguageCode.EN)]
+        [DataRow(LanguageCode.AA)]
+        [DataRow(LanguageCode.DE)]
+        [DataRow(LanguageCode.RU)]
+        public void CheckAllCultureWithDefault(LanguageCode defaultLanguageCode)
+        {
+            ICountryProvider countryProvider = new CountryProvider();
+            CultureInfo[] cultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+
+            foreach (var countryCode in (Alpha2Code[])Enum.GetValues(typeof(Alpha2Code)))
+            {
+                var countryInfo = countryProvider.GetCountry(countryCode);
+                if (countryInfo == null)
+                    continue;
+
+                var expectedLanguages = countryInfo.Translations.Select(x => x.LanguageCode).ToList();
+                foreach (var culture in cultures)
+                {
+                    bool expectResult = false;
+                    if (Enum.TryParse(culture.TwoLetterISOLanguageName, true, out LanguageCode code) == true)
+                    {
+                        expectResult = expectedLanguages.Any(x => x == code);
+                    }
+
+                    var translatedCountryName = countryProvider.GetCountryTranslatedName(countryCode, culture, defaultLanguageCode);
+                    if (expectResult == true && String.IsNullOrWhiteSpace(translatedCountryName) == true)
+                    {
+                        Assert.Fail($"A result was expected but there was no translated country name found for {countryCode} and culture {culture.Name} (language {culture.TwoLetterISOLanguageName})");
+                    }
+                    else
+                    {
+                        expectResult = expectedLanguages.Any(x => x == defaultLanguageCode);
+                        if (expectResult == true && String.IsNullOrWhiteSpace(translatedCountryName) == true)
+                        {
+                            Assert.Fail($"A result was expected for default value but there was no translated country name found for {countryCode} and default language code {defaultLanguageCode}");
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/Nager.Country/CountryProvider.cs
+++ b/src/Nager.Country/CountryProvider.cs
@@ -320,17 +320,17 @@ namespace Nager.Country
 
         public string GetCountryTranslatedName(string alpha2or3Code, LanguageCode languageCode)
         {
-            return GetCountryTranslatedName(GetCountry(alpha2or3Code), languageCode);
+            return this.GetCountryTranslatedName(GetCountry(alpha2or3Code), languageCode);
         }
 
         public string GetCountryTranslatedName(Alpha2Code alpha2Code, LanguageCode languageCode)
         {
-            return GetCountryTranslatedName(GetCountry(alpha2Code), languageCode);
+            return this.GetCountryTranslatedName(GetCountry(alpha2Code), languageCode);
         }
 
         public string GetCountryTranslatedName(Alpha3Code alpha3Code, LanguageCode languageCode)
         {
-            return GetCountryTranslatedName(GetCountry(alpha3Code), languageCode);
+            return this.GetCountryTranslatedName(GetCountry(alpha3Code), languageCode);
         }
 
         public string GetCountryTranslatedName(string alpha2or3Code, string languageCode)
@@ -380,25 +380,31 @@ namespace Nager.Country
 
         public string GetCountryTranslatedName(string alpha2or3Code, CultureInfo culture, LanguageCode defaultLanguageCode)
         {
-            string name = this.GetCountryTranslatedName(alpha2or3Code, culture);
-            if (String.IsNullOrWhiteSpace(name) == true)
+            var name = this.GetCountryTranslatedName(alpha2or3Code, culture);
+            if (string.IsNullOrWhiteSpace(name) == true)
+            {
                 name = this.GetCountryTranslatedName(alpha2or3Code, defaultLanguageCode);
+            }
             return name;
         }
 
         public string GetCountryTranslatedName(Alpha2Code alpha2Code, CultureInfo culture, LanguageCode defaultLanguageCode)
         {
-            string name = this.GetCountryTranslatedName(alpha2Code, culture);
-            if (String.IsNullOrWhiteSpace(name) == true)
+            var name = this.GetCountryTranslatedName(alpha2Code, culture);
+            if (string.IsNullOrWhiteSpace(name) == true)
+            {
                 name = this.GetCountryTranslatedName(alpha2Code, defaultLanguageCode);
+            }
             return name;
         }
 
         public string GetCountryTranslatedName(Alpha3Code alpha3Code, CultureInfo culture, LanguageCode defaultLanguageCode)
         {
-            string name = this.GetCountryTranslatedName(alpha3Code, culture);
-            if (String.IsNullOrWhiteSpace(name) == true)
+            var name = this.GetCountryTranslatedName(alpha3Code, culture);
+            if (string.IsNullOrWhiteSpace(name) == true)
+            {
                 name = this.GetCountryTranslatedName(alpha3Code, defaultLanguageCode);
+            }
             return name;
         }
 

--- a/src/Nager.Country/CountryProvider.cs
+++ b/src/Nager.Country/CountryProvider.cs
@@ -1,6 +1,8 @@
 ﻿using Nager.Country.CountryInfo;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 
 namespace Nager.Country
 {
@@ -276,6 +278,11 @@ namespace Nager.Country
             #endregion
         }
 
+        public IEnumerable<ICountryInfo> GetCountries()
+        {
+            return this._alpha2Code2CountryInfo.Values;
+        }
+
         public ICountryInfo GetCountry(string alpha2or3Code)
         {
             if (Enum.TryParse(alpha2or3Code, true, out Alpha2Code alpha2Code))
@@ -306,6 +313,100 @@ namespace Nager.Country
             if (this._alpha3Code2CountryInfo.TryGetValue(alpha3Code, out ICountryInfo countryInfo))
             {
                 return countryInfo;
+            }
+
+            return null;
+        }
+
+        public string GetCountryTranslatedName(string alpha2or3Code, LanguageCode languageCode)
+        {
+            return GetCountryTranslatedName(GetCountry(alpha2or3Code), languageCode);
+        }
+
+        public string GetCountryTranslatedName(Alpha2Code alpha2Code, LanguageCode languageCode)
+        {
+            return GetCountryTranslatedName(GetCountry(alpha2Code), languageCode);
+        }
+
+        public string GetCountryTranslatedName(Alpha3Code alpha3Code, LanguageCode languageCode)
+        {
+            return GetCountryTranslatedName(GetCountry(alpha3Code), languageCode);
+        }
+
+        public string GetCountryTranslatedName(string alpha2or3Code, string languageCode)
+        {
+            if (Enum.TryParse(languageCode, true, out LanguageCode code))
+            {
+                return this.GetCountryTranslatedName(alpha2or3Code, code);
+            }
+
+            return null;
+        }
+
+        public string GetCountryTranslatedName(Alpha2Code alpha2Code, string languageCode)
+        {
+            if (Enum.TryParse(languageCode, true, out LanguageCode code))
+            {
+                return this.GetCountryTranslatedName(alpha2Code, code);
+            }
+
+            return null;
+        }
+
+        public string GetCountryTranslatedName(Alpha3Code alpha3Code, string languageCode)
+        {
+            if (Enum.TryParse(languageCode, true, out LanguageCode code))
+            {
+                return this.GetCountryTranslatedName(alpha3Code, code);
+            }
+
+            return null;
+        }
+
+        public string GetCountryTranslatedName(string alpha2or3Code, CultureInfo culture)
+        {
+            return this.GetCountryTranslatedName(alpha2or3Code, culture.TwoLetterISOLanguageName);
+        }
+
+        public string GetCountryTranslatedName(Alpha2Code alpha2Code, CultureInfo culture)
+        {
+            return this.GetCountryTranslatedName(alpha2Code, culture.TwoLetterISOLanguageName);
+        }
+
+        public string GetCountryTranslatedName(Alpha3Code alpha3Code, CultureInfo culture)
+        {
+            return this.GetCountryTranslatedName(alpha3Code, culture.TwoLetterISOLanguageName);
+        }
+
+        public string GetCountryTranslatedName(string alpha2or3Code, CultureInfo culture, LanguageCode defaultLanguageCode)
+        {
+            string name = this.GetCountryTranslatedName(alpha2or3Code, culture);
+            if (String.IsNullOrWhiteSpace(name) == true)
+                name = this.GetCountryTranslatedName(alpha2or3Code, defaultLanguageCode);
+            return name;
+        }
+
+        public string GetCountryTranslatedName(Alpha2Code alpha2Code, CultureInfo culture, LanguageCode defaultLanguageCode)
+        {
+            string name = this.GetCountryTranslatedName(alpha2Code, culture);
+            if (String.IsNullOrWhiteSpace(name) == true)
+                name = this.GetCountryTranslatedName(alpha2Code, defaultLanguageCode);
+            return name;
+        }
+
+        public string GetCountryTranslatedName(Alpha3Code alpha3Code, CultureInfo culture, LanguageCode defaultLanguageCode)
+        {
+            string name = this.GetCountryTranslatedName(alpha3Code, culture);
+            if (String.IsNullOrWhiteSpace(name) == true)
+                name = this.GetCountryTranslatedName(alpha3Code, defaultLanguageCode);
+            return name;
+        }
+
+        private string GetCountryTranslatedName(ICountryInfo countryInfo, LanguageCode languageCode)
+        {
+            if (countryInfo != null && countryInfo.Translations != null && countryInfo.Translations.Length > 0)
+            {
+                return countryInfo.Translations.Where(x => x.LanguageCode == languageCode).Select(x => x.Name).FirstOrDefault();
             }
 
             return null;

--- a/src/Nager.Country/ICountryProvider.cs
+++ b/src/Nager.Country/ICountryProvider.cs
@@ -1,10 +1,30 @@
-﻿namespace Nager.Country
+﻿using System.Collections.Generic;
+using System.Globalization;
+
+namespace Nager.Country
 {
     public interface ICountryProvider
     {
-        ICountryInfo GetCountry(string alpha2or3Code);
+        IEnumerable<ICountryInfo> GetCountries();
 
+        ICountryInfo GetCountry(string alpha2or3Code);
         ICountryInfo GetCountry(Alpha2Code alpha2Code);
         ICountryInfo GetCountry(Alpha3Code alpha3Code);
+
+        string GetCountryTranslatedName(string alpha2or3Code, LanguageCode languageCode);
+        string GetCountryTranslatedName(Alpha2Code alpha2Code, LanguageCode languageCode);
+        string GetCountryTranslatedName(Alpha3Code alpha3Code, LanguageCode languageCode);
+
+        string GetCountryTranslatedName(string alpha2or3Code, string languageCode);
+        string GetCountryTranslatedName(Alpha2Code alpha2Code, string languageCode);
+        string GetCountryTranslatedName(Alpha3Code alpha3Code, string languageCode);
+
+        string GetCountryTranslatedName(string alpha2or3Code, CultureInfo culture);
+        string GetCountryTranslatedName(Alpha2Code alpha2Code, CultureInfo culture);
+        string GetCountryTranslatedName(Alpha3Code alpha3Code, CultureInfo culture);
+
+        string GetCountryTranslatedName(string alpha2or3Code, CultureInfo culture, LanguageCode defaultLanguageCode);
+        string GetCountryTranslatedName(Alpha2Code alpha2Code, CultureInfo culture, LanguageCode defaultLanguageCode);
+        string GetCountryTranslatedName(Alpha3Code alpha3Code, CultureInfo culture, LanguageCode defaultLanguageCode);
     }
 }


### PR DESCRIPTION
I'm using this awesome library and I think those helpers may be a cool add :
- get country list
- get translated name from country code and language code (if exists)
- get translated name from country code and CultureInfo (if exists ro default)